### PR TITLE
1.16.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ yarn_mappings=1.16.5+build.10
 loader_version=0.12.12
 
 # Mod Properties
-mod_version=1.2.0
+mod_version=1.2.1
 maven_group=me.wurgo
 archives_base_name=antiresourcereload

--- a/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
+++ b/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
@@ -7,10 +7,7 @@ import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
 public class AntiResourceReload implements ModInitializer {
     private static final Logger LOGGER = LogManager.getLogger(FabricLoader.getInstance().getModContainer("antiresourcereload").get().getMetadata().getName());
@@ -20,6 +17,7 @@ public class AntiResourceReload implements ModInitializer {
     }
 
     public static Map<Identifier, JsonElement> recipes;
+    public static boolean hasSeenRecipes;
 
     @Override
     public void onInitialize() {

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -1,18 +1,14 @@
 package me.wurgo.antiresourcereload.mixin;
 
-import com.google.gson.JsonElement;
 import me.wurgo.antiresourcereload.AntiResourceReload;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.recipe.RecipeManager;
 import net.minecraft.resource.*;
 import net.minecraft.server.command.CommandManager;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -27,7 +23,10 @@ public abstract class MinecraftClientMixin {
         else if (this.managerProvider == null) { AntiResourceReload.log("Cached resources unavailable, reloading & caching."); }
         else {
             AntiResourceReload.log("Using cached server resources.");
-            ((RecipeManagerAccess)this.managerProvider.get().getRecipeManager()).invokeApply(AntiResourceReload.recipes, null, null);
+            if(AntiResourceReload.hasSeenRecipes){
+                ((RecipeManagerAccess)this.managerProvider.get().getRecipeManager()).invokeApply(AntiResourceReload.recipes, null, null);
+            }
+            AntiResourceReload.hasSeenRecipes=false;
             return this.managerProvider;
         }
 

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeBookWidgetMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeBookWidgetMixin.java
@@ -1,0 +1,16 @@
+package me.wurgo.antiresourcereload.mixin;
+
+import me.wurgo.antiresourcereload.AntiResourceReload;
+import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RecipeBookWidget.class)
+public class RecipeBookWidgetMixin {
+    @Inject(method = "initialize",at = @At("HEAD"))
+    public void updateHasSeenRecipes(CallbackInfo ci){
+        AntiResourceReload.hasSeenRecipes=true;
+    }
+}

--- a/src/main/resources/antiresourcereload.mixins.json
+++ b/src/main/resources/antiresourcereload.mixins.json
@@ -7,7 +7,8 @@
     "MinecraftClientMixin",
     "ServerResourceManagerMixin",
     "RecipeManagerAccess",
-    "RecipeManagerMixin"
+    "RecipeManagerMixin",
+    "RecipeBookWidgetMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Recipes only get reloaded when the recipe book widget has gotten initialized, which happens when opening any interface with a recipe book. That leads to a boost in world generation speed for all worlds the player hasn't opened such a screen.