### PR TITLE
1.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ yarn_mappings=1.17.1+build.65
 loader_version=0.12.12
 
 # Mod Properties
-mod_version=1.2.0
+mod_version=1.2.1
 maven_group=me.wurgo
 archives_base_name=antiresourcereload

--- a/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
+++ b/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
@@ -16,6 +16,7 @@ public class AntiResourceReload implements ModInitializer {
         LOGGER.info("[AntiResourceReload] " + message);
     }
     public static Map<Identifier, JsonElement> recipes;
+    public static boolean hasSeenRecipes;
 
     @Override
     public void onInitialize() {

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -19,12 +19,15 @@ public abstract class MinecraftClientMixin {
     private CompletableFuture<ServerResourceManager> managerProvider;
 
     @Redirect(method = "createIntegratedResourceManager", at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/ServerResourceManager;reload(Ljava/util/List;Lnet/minecraft/util/registry/DynamicRegistryManager;Lnet/minecraft/server/command/CommandManager$RegistrationEnvironment;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
-    private CompletableFuture<ServerResourceManager> antiresourcereload_cachedReload(List<ResourcePack> dataPacks, DynamicRegistryManager registryManager, CommandManager.RegistrationEnvironment registrationEnvironment, int i, Executor executor, Executor executor2) {
+    private CompletableFuture<ServerResourceManager> antiresourcereload_cachedReload(List<ResourcePack> dataPacks, DynamicRegistryManager registryManager, CommandManager.RegistrationEnvironment registrationEnvironment, int i, Executor executor, Executor executor2) throws ExecutionException, InterruptedException {
         if (dataPacks.size() != 1) { AntiResourceReload.log("Using data-packs, reloading."); }
         else if (this.managerProvider == null) { AntiResourceReload.log("Cached resources unavailable, reloading & caching."); }
         else {
             AntiResourceReload.log("Using cached server resources.");
-            ((RecipeManagerAccess)this.managerProvider.get().getRecipeManager()).invokeApply(AntiResourceReload.recipes, null, null);
+            if(AntiResourceReload.hasSeenRecipes){
+                ((RecipeManagerAccess)this.managerProvider.get().getRecipeManager()).invokeApply(AntiResourceReload.recipes, null, null);
+            }
+            AntiResourceReload.hasSeenRecipes=false;
             return this.managerProvider;
         }
 

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeBookWidgetMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeBookWidgetMixin.java
@@ -1,0 +1,16 @@
+package me.wurgo.antiresourcereload.mixin;
+
+import me.wurgo.antiresourcereload.AntiResourceReload;
+import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RecipeBookWidget.class)
+public class RecipeBookWidgetMixin {
+    @Inject(method = "initialize",at = @At("HEAD"))
+    public void updateHasSeenRecipes(CallbackInfo ci){
+        AntiResourceReload.hasSeenRecipes=true;
+    }
+}

--- a/src/main/resources/antiresourcereload.mixins.json
+++ b/src/main/resources/antiresourcereload.mixins.json
@@ -7,7 +7,8 @@
     "MinecraftClientMixin",
     "ServerResourceManagerMixin",
     "RecipeManagerMixin",
-    "RecipeManagerAccess"
+    "RecipeManagerAccess",
+    "RecipeBookWidgetMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Recipes only get reloaded when the recipe book widget has gotten initialized, which happens when opening any interface with a recipe book. That leads to a boost in world generation speed for all worlds the player hasn't opened such a screen.